### PR TITLE
Add editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{html,md,js,css,sql}]
+indent_size = 2
+
+[*.py]
+indent_size = 4


### PR DESCRIPTION
Add same .editorconfig file as Web Almanac repo.

IDEs that support it, will then format files according to our linting rules.

To quote from[that README](https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/src/README.md#style-guide):

> An `.editorconfig` file exists for those using [EditorConfig](https://editorconfig.org/) to help enforce those styles. This may require installing the `editorconfig` node module via npm (we suggest installing globally - `npm install -g editorconfig` ) and then installing the extension for your IDE (for example there is a [Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig)).