### PR TITLE
Remove page field from summary tables

### DIFF
--- a/modules/transformation.py
+++ b/modules/transformation.py
@@ -189,9 +189,6 @@ class ImportHarJson(beam.DoFn):
             ret_request = {
                 "client": status_info["client"],
                 "date": status_info["date"],
-                # TODO future improvement, not populated as of 2022-05
-                "page": status_info["page"],
-                # TODO deprecate in favor of newer `page` field
                 "pageid": status_info["pageid"],
                 "crawlid": status_info["crawlid"],
                 # we use this below for expAge calculation
@@ -413,12 +410,7 @@ class ImportHarJson(beam.DoFn):
             "metadata": json.dumps(page.get("_metadata")),  # TODO TEST ME
             "client": status_info["client"],
             "date": status_info["date"],
-            "page": status_info[
-                "page"
-            ],  # TODO future improvement, not populated as of 2022-05
-            "pageid": status_info[
-                "pageid"
-            ],  # TODO deprecate in favor of newer `page` field
+            "pageid": status_info["pageid"],
             "createDate": int(datetime.datetime.now().timestamp()),
             "startedDateTime": utils.datetime_to_epoch(
                 page["startedDateTime"], status_info


### PR DESCRIPTION
Now that we've fixed the `url` field corresponding to the test page, we can remove the `page` field. This wasn't specified in the schema so I'm not sure if it would have gotten silently dropped or caused an issue with the pipeline. In either case, it's not needed any more so we can drop it.