### PR TITLE
Clamp integers at BigQuery's max int

### DIFF
--- a/modules/transformation.py
+++ b/modules/transformation.py
@@ -312,7 +312,7 @@ class ImportHarJson(beam.DoFn):
                 exp_age = 0
             elif cc and re.match(r"max-age=\d+", cc):
                 try:
-                    exp_age = int(re.findall(r"\d+", cc)[0])
+                    exp_age = utils.clamp_integer(re.findall(r"\d+", cc)[0])
                 except Exception:
                     # TODO compare results from old and new pipeline for these errors
                     logging.warning(f"Unable to parse max-age, cc:{cc}", exc_info=True)

--- a/modules/transformation.py
+++ b/modules/transformation.py
@@ -110,8 +110,8 @@ def initialize_status_info(file_name, page):
         "wptid": page.get("testID", base_name.split(".")[0]),
         "medianRun": 1,  # only available in RAW json (median.firstview.run), not HAR json
         "page": metadata.get("tested_url", ""),
-        "pageid": int(metadata["page_id"]) if metadata.get("page_id") else None,
-        "rank": int(metadata["rank"]) if metadata.get("rank") else None,
+        "pageid": utils.clamp_integer(metadata["page_id"]) if metadata.get("page_id") else None,
+        "rank": utils.clamp_integer(metadata["rank"]) if metadata.get("rank") else None,
         "date": "{:%Y_%m_%d}".format(date),
         "client": metadata.get("layout", utils.client_name(file_name)).lower(),
     }
@@ -411,7 +411,7 @@ class ImportHarJson(beam.DoFn):
             "client": status_info["client"],
             "date": status_info["date"],
             "pageid": status_info["pageid"],
-            "createDate": int(datetime.datetime.now().timestamp()),
+            "createDate": utils.clamp_integer(datetime.datetime.now().timestamp()),
             "startedDateTime": utils.datetime_to_epoch(
                 page["startedDateTime"], status_info
             ),
@@ -574,11 +574,11 @@ class ImportHarJson(beam.DoFn):
 
         ret = {
             "reqTotal": req_total,
-            "bytesTotal": bytes_total,
+            "bytesTotal": utils.clamp_integer(bytes_total),
             "reqJS": count["script"],
-            "bytesJS": size["script"],
+            "bytesJS": utils.clamp_integer(size["script"]),
             "reqImg": count["image"],
-            "bytesImg": size["image"],
+            "bytesImg": utils.clamp_integer(size["image"]),
             "reqJson": 0,
             "bytesJson": 0,
         }
@@ -586,7 +586,7 @@ class ImportHarJson(beam.DoFn):
             ret.update(
                 {
                     "req{}".format(typ.title()): count[typ],
-                    "bytes{}".format(typ.title()): size[typ],
+                    "bytes{}".format(typ.title()): utils.clamp_integer(size[typ]),
                 }
             )
 
@@ -599,7 +599,7 @@ class ImportHarJson(beam.DoFn):
                 "maxage30": max_age_30,
                 "maxage365": max_age_365,
                 "maxageMore": max_age_more,
-                "bytesHtmlDoc": bytes_html_doc,
+                "bytesHtmlDoc": utils.clamp_integer(bytes_html_doc),
                 "numRedirects": num_redirects,
                 "numErrors": num_errors,
                 "numGlibs": num_glibs,

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -7,7 +7,7 @@ import dateutil.parser
 from modules import constants
 
 
-MAX_INT = 2**63-1
+BIGQUERY_MAX_INT = 2**63-1
 
 
 def remove_empty_keys(d):
@@ -177,4 +177,4 @@ def crawl_date(dir_name):
 
 
 def clamp_integer(n):
-    return min(MAX_INT, int(n))
+    return min(BIGQUERY_MAX_INT, int(n))

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -7,6 +7,9 @@ import dateutil.parser
 from modules import constants
 
 
+MAX_INT = 2**63-1
+
+
 def remove_empty_keys(d):
     return {k: v for k, v in d if v is not None}
 
@@ -171,3 +174,7 @@ def crawl_date(dir_name):
     return dateutil.parser.parse(
         dir_name.split("/")[-1].split("-")[1].replace("_", " ")
     )
+
+
+def clamp_integer(n):
+    return min(MAX_INT, int(n))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -136,4 +136,4 @@ class Test(TestCase):
         self.assertEqual(utils.clamp_integer('1000'), 1000)
 
     def test_clamp_integer_bigint(self):
-        self.assertEqual(utils.clamp_integer(2**64), utils.MAX_INT)
+        self.assertEqual(utils.clamp_integer(2**64), utils.BIGQUERY_MAX_INT)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -125,3 +125,15 @@ class Test(TestCase):
     def test_crawl_date(self):
         dir_name = "gs://httparchive/crawls/android-Apr_1_2022"
         self.assertEqual(utils.crawl_date(dir_name), datetime.datetime(2022, 4, 1, 0, 0))
+
+    def test_clamp_integer_normal(self):
+        self.assertEqual(utils.clamp_integer(1000), 1000)
+
+    def test_clamp_integer_negative(self):
+        self.assertEqual(utils.clamp_integer(-1000), -1000)
+
+    def test_clamp_integer_str(self):
+        self.assertEqual(utils.clamp_integer('1000'), 1000)
+
+    def test_clamp_integer_bigint(self):
+        self.assertEqual(utils.clamp_integer(2**64), utils.MAX_INT)


### PR DESCRIPTION
Fixes #52 

Ensures that no `exp_age` value exceeds 64 bits.

- New `utils.MAX_INT` const
- New `utils.clamp_integer` function
- Pass the `exp_age` value through the new function
- Pass every other string-to-int value through just to be safe
- Adds tests