### PR TITLE
Add guards to reduce batch pipeline errors

### DIFF
--- a/modules/transformation.py
+++ b/modules/transformation.py
@@ -122,8 +122,10 @@ class ImportHarJson(beam.DoFn):
         file_name, data = element
         try:
             page, requests = self.generate_pages(file_name, data)
-            yield beam.pvalue.TaggedOutput("page", page)
-            yield beam.pvalue.TaggedOutput("requests", requests)
+            if page:
+                yield beam.pvalue.TaggedOutput("page", page)
+            if requests:
+                yield beam.pvalue.TaggedOutput("requests", requests)
         except Exception:
             logging.exception(
                 f"Unable to unpack HAR, check previous logs for detailed errors. "

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -155,10 +155,14 @@ def client_name(file_name):
 
 
 def format_table_name(row, table):
-    return "{}.{}_{}".format(
+    table_name = "{}.{}_{}".format(
         constants.bigquery["datasets"][table], row["date"], row["client"]
     )
 
+    if not table_name:
+        logging.error(f"Unable to determine full table name. table={table},row={row}")
+
+    return table_name
 
 def datetime_to_epoch(dt, status_info):
     try:

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -164,6 +164,7 @@ def format_table_name(row, table):
 
     return table_name
 
+
 def datetime_to_epoch(dt, status_info):
     try:
         return int(round(dateutil.parser.parse(dt).timestamp()))


### PR DESCRIPTION
### Changes
- Adds logging during BigQuery table name generation
- Prevent empty pages or requests from reaching downstream processes (e.g. BigQuery)

### Context

Responding to this issue when running in batch mode during testing.

<details>
  <summary>Click to expand for stacktrace</summary>

```
Traceback (most recent call last):
  File "run_pipeline.py", line 7, in <module>
    import_har.run()
  File "/mnt/d/development/projects/HTTPArchive/data-pipeline/modules/import_har.py", line 73, in run
    (
  File "/home/giancarlo/.local/lib/python3.8/site-packages/apache_beam/pipeline.py", line 597, in __exit__
    self.result.wait_until_finish()
  File "/home/giancarlo/.local/lib/python3.8/site-packages/apache_beam/runners/dataflow/dataflow_runner.py", line 1636, in wait_until_finish
    raise DataflowRuntimeException(
apache_beam.runners.dataflow.dataflow_runner.DataflowRuntimeException: Dataflow pipeline failed. State: FAILED, Error:
Traceback (most recent call last):
  File "apache_beam/runners/common.py", line 1198, in apache_beam.runners.common.DoFnRunner.process
  File "apache_beam/runners/common.py", line 536, in apache_beam.runners.common.SimpleInvoker.invoke_process
  File "apache_beam/runners/common.py", line 1334, in apache_beam.runners.common._OutputProcessor.process_outputs
  File "/usr/local/lib/python3.8/site-packages/apache_beam/io/gcp/bigquery_tools.py", line 1705, in process
    yield (self.destination(element, *side_inputs), element)
  File "/mnt/d/development/projects/HTTPArchive/data-pipeline/modules/import_har.py", line 53, in <lambda>
    table=lambda row: utils.format_table_name(row, "pages"),
  File "/usr/local/lib/python3.8/site-packages/modules/utils.py", line 159, in format_table_name
    constants.bigquery["datasets"][table], row["date"], row["client"]
TypeError: 'NoneType' object is not subscriptable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/apache_beam/runners/worker/sdk_worker.py", line 267, in _execute
    response = task()
  File "/usr/local/lib/python3.8/site-packages/apache_beam/runners/worker/sdk_worker.py", line 340, in <lambda>
    lambda: self.create_worker().do_instruction(request), request)
  File "/usr/local/lib/python3.8/site-packages/apache_beam/runners/worker/sdk_worker.py", line 580, in do_instruction
    return getattr(self, request_type)(
  File "/usr/local/lib/python3.8/site-packages/apache_beam/runners/worker/sdk_worker.py", line 618, in process_bundle
    bundle_processor.process_bundle(instruction_id))
  File "/usr/local/lib/python3.8/site-packages/apache_beam/runners/worker/bundle_processor.py", line 995, in process_bundle
    input_op_by_transform_id[element.transform_id].process_encoded(
  File "/usr/local/lib/python3.8/site-packages/apache_beam/runners/worker/bundle_processor.py", line 221, in process_encoded
    self.output(decoded_value)
  File "apache_beam/runners/worker/operations.py", line 346, in apache_beam.runners.worker.operations.Operation.output
  File "apache_beam/runners/worker/operations.py", line 348, in apache_beam.runners.worker.operations.Operation.output
  File "apache_beam/runners/worker/operations.py", line 215, in apache_beam.runners.worker.operations.SingletonConsumerSet.receive
  File "apache_beam/runners/worker/operations.py", line 707, in apache_beam.runners.worker.operations.DoOperation.process
  File "apache_beam/runners/worker/operations.py", line 708, in apache_beam.runners.worker.operations.DoOperation.process
  File "apache_beam/runners/common.py", line 1200, in apache_beam.runners.common.DoFnRunner.process
  File "apache_beam/runners/common.py", line 1265, in apache_beam.runners.common.DoFnRunner._reraise_augmented
  File "apache_beam/runners/common.py", line 1198, in apache_beam.runners.common.DoFnRunner.process
  File "apache_beam/runners/common.py", line 536, in apache_beam.runners.common.SimpleInvoker.invoke_process
  File "apache_beam/runners/common.py", line 1361, in apache_beam.runners.common._OutputProcessor.process_outputs
  File "apache_beam/runners/worker/operations.py", line 215, in apache_beam.runners.worker.operations.SingletonConsumerSet.receive
  File "apache_beam/runners/worker/operations.py", line 707, in apache_beam.runners.worker.operations.DoOperation.process
  File "apache_beam/runners/worker/operations.py", line 708, in apache_beam.runners.worker.operations.DoOperation.process
  File "apache_beam/runners/common.py", line 1200, in apache_beam.runners.common.DoFnRunner.process
  File "apache_beam/runners/common.py", line 1265, in apache_beam.runners.common.DoFnRunner._reraise_augmented
  File "apache_beam/runners/common.py", line 1198, in apache_beam.runners.common.DoFnRunner.process
  File "apache_beam/runners/common.py", line 536, in apache_beam.runners.common.SimpleInvoker.invoke_process
  File "apache_beam/runners/common.py", line 1361, in apache_beam.runners.common._OutputProcessor.process_outputs
  File "apache_beam/runners/worker/operations.py", line 215, in apache_beam.runners.worker.operations.SingletonConsumerSet.receive
  File "apache_beam/runners/worker/operations.py", line 707, in apache_beam.runners.worker.operations.DoOperation.process
  File "apache_beam/runners/worker/operations.py", line 708, in apache_beam.runners.worker.operations.DoOperation.process
  File "apache_beam/runners/common.py", line 1200, in apache_beam.runners.common.DoFnRunner.process
  File "apache_beam/runners/common.py", line 1265, in apache_beam.runners.common.DoFnRunner._reraise_augmented
  File "apache_beam/runners/common.py", line 1198, in apache_beam.runners.common.DoFnRunner.process
  File "apache_beam/runners/common.py", line 536, in apache_beam.runners.common.SimpleInvoker.invoke_process
  File "apache_beam/runners/common.py", line 1361, in apache_beam.runners.common._OutputProcessor.process_outputs
  File "apache_beam/runners/worker/operations.py", line 215, in apache_beam.runners.worker.operations.SingletonConsumerSet.receive
  File "apache_beam/runners/worker/operations.py", line 707, in apache_beam.runners.worker.operations.DoOperation.process
  File "apache_beam/runners/worker/operations.py", line 708, in apache_beam.runners.worker.operations.DoOperation.process
  File "apache_beam/runners/common.py", line 1200, in apache_beam.runners.common.DoFnRunner.process
  File "apache_beam/runners/common.py", line 1265, in apache_beam.runners.common.DoFnRunner._reraise_augmented
  File "apache_beam/runners/common.py", line 1198, in apache_beam.runners.common.DoFnRunner.process
  File "apache_beam/runners/common.py", line 536, in apache_beam.runners.common.SimpleInvoker.invoke_process
  File "apache_beam/runners/common.py", line 1363, in apache_beam.runners.common._OutputProcessor.process_outputs
  File "apache_beam/runners/worker/operations.py", line 212, in apache_beam.runners.worker.operations.SingletonConsumerSet.receive
  File "apache_beam/runners/worker/operations.py", line 215, in apache_beam.runners.worker.operations.SingletonConsumerSet.receive
  File "apache_beam/runners/worker/operations.py", line 707, in apache_beam.runners.worker.operations.DoOperation.process
  File "apache_beam/runners/worker/operations.py", line 708, in apache_beam.runners.worker.operations.DoOperation.process
  File "apache_beam/runners/common.py", line 1200, in apache_beam.runners.common.DoFnRunner.process
  File "apache_beam/runners/common.py", line 1281, in apache_beam.runners.common.DoFnRunner._reraise_augmented
  File "apache_beam/runners/common.py", line 1198, in apache_beam.runners.common.DoFnRunner.process
  File "apache_beam/runners/common.py", line 536, in apache_beam.runners.common.SimpleInvoker.invoke_process
  File "apache_beam/runners/common.py", line 1334, in apache_beam.runners.common._OutputProcessor.process_outputs
  File "/usr/local/lib/python3.8/site-packages/apache_beam/io/gcp/bigquery_tools.py", line 1705, in process
    yield (self.destination(element, *side_inputs), element)
  File "/mnt/d/development/projects/HTTPArchive/data-pipeline/modules/import_har.py", line 53, in <lambda>
    table=lambda row: utils.format_table_name(row, "pages"),
  File "/usr/local/lib/python3.8/site-packages/modules/utils.py", line 159, in format_table_name
    constants.bigquery["datasets"][table], row["date"], row["client"]
TypeError: 'NoneType' object is not subscriptable [while running 'WritePagesToBigQuery/WriteToBigQuery/_StreamToBigQuery/AppendDestination-ptransform-138']
```

</details>

### Validation
Successful batch job
https://console.cloud.google.com/dataflow/jobs/us-west1/2022-05-21_18_17_07-5973782900081194323;step=?project=httparchive&cloudshell=false