### PR TITLE
Write home-page-only data to separate tables

### DIFF
--- a/modules/constants.py
+++ b/modules/constants.py
@@ -6,6 +6,8 @@ bigquery = {
     "datasets": {
         "pages": "httparchive:experimental_summary_pages",
         "requests": "httparchive:experimental_summary_requests",
+        "home_pages": "httparchive:summary_pages",
+        "home_requests": "httparchive:summary_requests",
     },
     "schemas": {
         "pages": {

--- a/modules/import_har.py
+++ b/modules/import_har.py
@@ -51,34 +51,42 @@ def run(argv=None):
         lambda elements: elements
     )
 
-    pages_errors = pages | "WritePagesToBigQuery" >> WriteBigQuery(
+    home_pages = pages | "FilterHomePages" >> beam.Filter(utils.is_home_page)
+    home_requests = requests | "FilterHomeRequests" >> beam.Filter(utils.is_home_page)
+
+    deadletter_queues = {}
+
+    deadletter_queues["pages"] = pages | "WritePagesToBigQuery" >> WriteBigQuery(
         table=lambda row: utils.format_table_name(row, "pages"),
         schema=constants.bigquery["schemas"]["pages"],
         streaming=standard_options.streaming,
     )
 
-    requests_errors = requests | "WriteRequestsToBigQuery" >> WriteBigQuery(
+    deadletter_queues["requests"] = requests | "WriteRequestsToBigQuery" >> WriteBigQuery(
         table=lambda row: utils.format_table_name(row, "requests"),
+        schema=constants.bigquery["schemas"]["requests"],
+        streaming=standard_options.streaming,
+    )
+
+    deadletter_queues["home_pages"] = home_pages | "WriteHomePagesToBigQuery" >> WriteBigQuery(
+        table=lambda row: utils.format_table_name(row, "home_pages"),
+        schema=constants.bigquery["schemas"]["pages"],
+        streaming=standard_options.streaming,
+    )
+
+    deadletter_queues["home_requests"] = home_requests | "WriteHomeRequestsToBigQuery" >> WriteBigQuery(
+        table=lambda row: utils.format_table_name(row, "home_requests"),
         schema=constants.bigquery["schemas"]["requests"],
         streaming=standard_options.streaming,
     )
 
     # deadletter logging
     if standard_options.streaming:
-        (
-            pages_errors[BigQueryWriteFn.FAILED_ROWS]
-            | "PrintPagesErrors"
-            >> beam.FlatMap(
-                lambda e: logging.error(f"Could not load page to BigQuery: {e}")
+        for name, transform in deadletter_queues.items():
+            transform_name = f"Print{name.replace('_', ' ').title().replace(' ', '')}Errors"
+            transform[BigQueryWriteFn.FAILED_ROWS] | transform_name >> beam.FlatMap(
+                lambda e: logging.error(f"Could not load {name} to BigQuery: {e}")
             )
-        )
-        (
-            requests_errors[BigQueryWriteFn.FAILED_ROWS]
-            | "PrintRequestsErrors"
-            >> beam.FlatMap(
-                lambda e: logging.error(f"Could not load request to BigQuery: {e}")
-            )
-        )
 
     # TODO implement deadletter for FILE_LOADS?
     #  FAILED_ROWS not implemented for BigQueryBatchFileLoads in this version of beam (only _StreamToBigQuery)

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -206,6 +206,8 @@ def int_columns_for_schema(schema_name):
 def is_home_page(element):
     metadata = element.get("metadata")
     if metadata:
+        # use metadata.crawl_depth starting from 2022-05
         return json.loads(metadata).get("crawl_depth", 0) == 0
     else:
+        # legacy crawl data is all home-page only (i.e. no secondary pages)
         return True

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 import logging
 import os
 
@@ -200,3 +201,11 @@ def clamp_integers(data, columns):
 def int_columns_for_schema(schema_name):
     schema = constants.bigquery['schemas'][schema_name]['fields']
     return [field['name'] for field in schema if field['type'] == 'INTEGER']
+
+
+def is_home_page(element):
+    metadata = element.get("metadata")
+    if metadata:
+        return json.loads(metadata).get("crawl_depth", 0) == 0
+    else:
+        return True


### PR DESCRIPTION
Fixes #81 

### Changes

- add BigQuery write tasks and dead-letter queues for home-page-only tables
- add constants for home-page-only tables; using final destination (i.e. non-experimental) datasets
- condense definition of dead-letter queues


### Validation
https://console.cloud.google.com/dataflow/jobs/us-west1/2022-06-09_15_45_02-11679148253176106594?cloudshell=false&project=httparchive

Tested on a streaming job by routing _all_ data to `experimental_summary_*_2` and _home-page-only_ data to `experimental_summary_*_2_home` respectively.

ℹ️ Note: differences in counts are due to stopping the streaming pipeline mid-execution without fully draining

```sql
select
  cast(json_query(metadata, "$.crawl_depth") as INT64) as crawl_depth,
  count(*) as count,
  'experimental_summary_pages_2' as dataset,
  array_agg(DISTINCT _TABLE_SUFFIX) as tables
from `httparchive.experimental_summary_pages_2.*`
group by 1

union all

select
  cast(json_query(metadata, "$.crawl_depth") as INT64) as crawl_depth,
  count(*) as count,
  'experimental_summary_pages_2_home' as dataset,
  array_agg(DISTINCT _TABLE_SUFFIX) as tables
from `httparchive.experimental_summary_pages_2_home.*`
group by 1
```

```
|crawl_depth|count|dataset                          |tables                                |
|-----------|-----|---------------------------------|--------------------------------------|
|0          |3307 |experimental_summary_pages_2_home|[2022_06_01_desktop,2022_06_01_mobile]|
|0          |3755 |experimental_summary_pages_2     |[2022_06_01_mobile,2022_06_01_desktop]|
|1          |44   |experimental_summary_pages_2     |[2022_06_01_mobile,2022_06_01_desktop]|

```