### PR TITLE
Trim parsed_css from pages payload

### DIFF
--- a/modules/import_all.py
+++ b/modules/import_all.py
@@ -69,6 +69,7 @@ def get_page(har, client, crawl_date):
         rank = int(metadata.get('rank')) if metadata.get('rank') else None
 
     try:
+        page = trim_page(page)
         payload_json = to_json(page)
     except ValueError:
         logging.warning('Skipping pages payload for "%s": unable to stringify as JSON.', wptid)
@@ -388,6 +389,18 @@ def trim_request(request):
     request = deepcopy(request)
     request.get('response', {}).get('content', {}).pop('text', None)
     return request
+
+
+def trim_page(page):
+    """Removes unneeded fields from the page object."""
+
+    if not page:
+        return None
+
+    # Make a copy first so the data can be used later.
+    page = deepcopy(page)
+    page.pop('_parsed_css')
+    return page
 
 
 def to_json(obj):

--- a/modules/non_summary_pipeline.py
+++ b/modules/non_summary_pipeline.py
@@ -33,6 +33,7 @@ def get_page(har):
         url = metadata.get("tested_url", url)
 
     try:
+        page = trim_page(page)
         payload_json = to_json(page)
     except Exception:
         logging.warning(
@@ -172,6 +173,18 @@ def trim_request(request):
     request = deepcopy(request)
     request.get("response").get("content").pop("text", None)
     return request
+
+
+def trim_page(page):
+    """Removes unneeded fields from the page object."""
+
+    if not page:
+        return None
+
+    # Make a copy first so the data can be used later.
+    page = deepcopy(page)
+    page.pop("_parsed_css")
+    return page
 
 
 def hash_url(url):


### PR DESCRIPTION
Progress on #98

We're adding a new custom metric in https://github.com/HTTPArchive/custom-metrics/pull/44 but we don't want it to appear in the HAR payloads on BigQuery because of its size. This PR excludes it for now.

The custom metric is named `parsed_css` so it'll appear as `_parsed_css` within the page object.

Later, I'll adjust the pipeline so that we can write the new custom metric to its own table for analysis.