### PR TITLE
Ensure JSON pop has a default

### DIFF
--- a/modules/import_all.py
+++ b/modules/import_all.py
@@ -402,7 +402,7 @@ def trim_page(page):
 
     # Make a copy first so the data can be used later.
     page = deepcopy(page)
-    page.pop('_parsed_css')
+    page.pop('_parsed_css', None)
     return page
 
 

--- a/modules/non_summary_pipeline.py
+++ b/modules/non_summary_pipeline.py
@@ -187,7 +187,7 @@ def trim_page(page):
 
     # Make a copy first so the data can be used later.
     page = deepcopy(page)
-    page.pop("_parsed_css")
+    page.pop("_parsed_css", None)
     return page
 
 


### PR DESCRIPTION
This would have actually worked for the July crawl that has a `parsed_css` custom metric, but in the June test that I did, it was failing to pop the non-existent custom metric because I didn't supply a default value. Adding that in and running a test to validate that it's working. 