### PR TITLE
Combined pipeline fixes from July 2022 crawl

### DIFF
--- a/modules/combined_pipeline.py
+++ b/modules/combined_pipeline.py
@@ -52,6 +52,14 @@ class CombinedPipelineOptions(PipelineOptions):
             choices=bq_write_methods,
             default=WriteToBigQuery.Method.STREAMING_INSERTS,
         )
+        parser.add_argument(
+            "--big_query_triggering_frequency",
+            dest="triggering_frequency",
+            help="When method is FILE_LOADS: Value will be converted to int. Every triggering_frequency seconds, a "
+                 "BigQuery load job will be triggered for all the data written since the last load job.\n"
+                 "When method is STREAMING_INSERTS and with_auto_sharding=True: A streaming inserts batch will be "
+                 "submitted at least every triggering_frequency seconds when data is waiting."
+        )
 
         parser.add_argument(
             "--dataset_summary_pages",
@@ -159,11 +167,11 @@ def create_pipeline(argv=None):
         ).with_outputs("page", "requests")
 
         pages | summary_pipeline.WriteSummaryPagesToBigQuery(
-            combined_options, standard_options
+            combined_options, standard_options, **combined_options.get_all_options()
         )
 
         requests | summary_pipeline.WriteSummaryRequestsToBigQuery(
-            combined_options, standard_options
+            combined_options, standard_options, **combined_options.get_all_options()
         )
 
     # non-summary pipeline

--- a/modules/combined_pipeline.py
+++ b/modules/combined_pipeline.py
@@ -33,9 +33,7 @@ class CombinedPipelineOptions(PipelineOptions):
         group.add_argument(
             '--input_file',
             help="Input file containing a list of HAR files. "
-                 # editorconfig-checker-disable
-                 "Example: gs://httparchive/crawls_manifest/android-May_12_2022.txt"
-                 # editorconfig-checker-enable
+            "Example: gs://httparchive/crawls_manifest/android-May_12_2022.txt"
         )
 
         group.add_argument(
@@ -57,12 +55,10 @@ class CombinedPipelineOptions(PipelineOptions):
         parser.add_argument(
             "--big_query_triggering_frequency",
             dest="triggering_frequency",
-            # editorconfig-checker-disable
             help="When method is FILE_LOADS: Value will be converted to int. Every triggering_frequency seconds, a "
-                 "BigQuery load job will be triggered for all the data written since the last load job.\n"
-                 "When method is STREAMING_INSERTS and with_auto_sharding=True: A streaming inserts batch will be "
-                 "submitted at least every triggering_frequency seconds when data is waiting."
-            # editorconfig-checker-enable
+            "BigQuery load job will be triggered for all the data written since the last load job.\n"
+            "When method is STREAMING_INSERTS and with_auto_sharding=True: A streaming inserts batch will be "
+            "submitted at least every triggering_frequency seconds when data is waiting."
         )
 
         parser.add_argument(

--- a/modules/combined_pipeline.py
+++ b/modules/combined_pipeline.py
@@ -33,7 +33,9 @@ class CombinedPipelineOptions(PipelineOptions):
         group.add_argument(
             '--input_file',
             help="Input file containing a list of HAR files. "
+                 # editorconfig-checker-disable
                  "Example: gs://httparchive/crawls_manifest/android-May_12_2022.txt"
+                 # editorconfig-checker-enable
         )
 
         group.add_argument(
@@ -55,10 +57,12 @@ class CombinedPipelineOptions(PipelineOptions):
         parser.add_argument(
             "--big_query_triggering_frequency",
             dest="triggering_frequency",
+            # editorconfig-checker-disable
             help="When method is FILE_LOADS: Value will be converted to int. Every triggering_frequency seconds, a "
                  "BigQuery load job will be triggered for all the data written since the last load job.\n"
                  "When method is STREAMING_INSERTS and with_auto_sharding=True: A streaming inserts batch will be "
                  "submitted at least every triggering_frequency seconds when data is waiting."
+            # editorconfig-checker-enable
         )
 
         parser.add_argument(

--- a/modules/combined_pipeline.py
+++ b/modules/combined_pipeline.py
@@ -50,7 +50,7 @@ class CombinedPipelineOptions(PipelineOptions):
             dest="big_query_write_method",
             help=f"BigQuery write method. One of {','.join(bq_write_methods)}",
             choices=bq_write_methods,
-            default=WriteToBigQuery.Method.STREAMING_INSERTS,
+            default=WriteToBigQuery.Method.FILE_LOADS,
         )
         parser.add_argument(
             "--big_query_triggering_frequency",

--- a/modules/non_summary_pipeline.py
+++ b/modules/non_summary_pipeline.py
@@ -450,14 +450,6 @@ class WriteNonSummaryToBigQuery(beam.PTransform):
 
         home_only_rows = all_rows | f"Filter{formatted_name}{index}" >> beam.Filter(is_home_page)
 
-        # all_rows | f"Write{formatted_name}All{index}" >> transformation.WriteBigQuery(
-        #     table=lambda row: utils.format_table_name(row, table_all),
-        #     schema=schema,
-        #     streaming=self.streaming,
-        #     method=method if method else self.big_query_write_method,
-        #     triggering_frequency = self.triggering_frequency,
-        # )
-
         home_only_rows | f"Write{formatted_name}Home{index}" >> transformation.WriteBigQuery(
             table=lambda row: utils.format_table_name(row, table_home),
             schema=schema,

--- a/modules/non_summary_pipeline.py
+++ b/modules/non_summary_pipeline.py
@@ -448,12 +448,12 @@ class WriteNonSummaryToBigQuery(beam.PTransform):
 
         home_only_rows = all_rows | f"Filter{formatted_name}{index}" >> beam.Filter(is_home_page)
 
-        all_rows | f"Write{formatted_name}All{index}" >> transformation.WriteBigQuery(
-            table=lambda row: utils.format_table_name(row, table_all),
-            schema=schema,
-            streaming=self.streaming,
-            method=method if method else self.big_query_write_method,
-        )
+        # all_rows | f"Write{formatted_name}All{index}" >> transformation.WriteBigQuery(
+        #     table=lambda row: utils.format_table_name(row, table_all),
+        #     schema=schema,
+        #     streaming=self.streaming,
+        #     method=method if method else self.big_query_write_method,
+        # )
 
         home_only_rows | f"Write{formatted_name}Home{index}" >> transformation.WriteBigQuery(
             table=lambda row: utils.format_table_name(row, table_home),

--- a/modules/non_summary_pipeline.py
+++ b/modules/non_summary_pipeline.py
@@ -418,6 +418,7 @@ class WriteNonSummaryToBigQuery(beam.PTransform):
         dataset_requests_home_only,
         dataset_response_bodies_home_only,
         label=None,
+        triggering_frequency=None,
         **kwargs,
     ):
         # TODO(BEAM-6158): Revert the workaround once we can pickle super() on py3.
@@ -427,6 +428,7 @@ class WriteNonSummaryToBigQuery(beam.PTransform):
 
         self.streaming = streaming
         self.big_query_write_method = big_query_write_method
+        self.triggering_frequency = triggering_frequency
         self.partitions = partitions
         self.dataset_pages = dataset_pages
         self.dataset_technologies = dataset_technologies
@@ -453,6 +455,7 @@ class WriteNonSummaryToBigQuery(beam.PTransform):
         #     schema=schema,
         #     streaming=self.streaming,
         #     method=method if method else self.big_query_write_method,
+        #     triggering_frequency = self.triggering_frequency,
         # )
 
         home_only_rows | f"Write{formatted_name}Home{index}" >> transformation.WriteBigQuery(
@@ -460,6 +463,7 @@ class WriteNonSummaryToBigQuery(beam.PTransform):
             schema=schema,
             streaming=self.streaming,
             method=method if method else self.big_query_write_method,
+            triggering_frequency=self.triggering_frequency,
         )
 
     def expand(self, hars):

--- a/modules/summary_pipeline.py
+++ b/modules/summary_pipeline.py
@@ -1,17 +1,16 @@
 import apache_beam as beam
+from apache_beam.io.gcp import bigquery
 
-from modules import constants, utils
-from modules.transformation import (
-    WriteBigQuery,
-    add_deadletter_logging,
-)
+from modules import constants, utils, transformation
+from modules.transformation import add_deadletter_logging
 
 
 class WriteSummaryPagesToBigQuery(beam.PTransform):
-    def __init__(self, summary_options, standard_options, label=None):
+    def __init__(self, summary_options, standard_options, label=None, triggering_frequency=None, **kwargs):
         super().__init__(label)
         self.summary_options = summary_options
         self.standard_options = standard_options
+        self.triggering_frequency = triggering_frequency
 
     def expand(self, pages):
         home_pages = pages | "FilterHomePages" >> beam.Filter(utils.is_home_page)
@@ -19,35 +18,38 @@ class WriteSummaryPagesToBigQuery(beam.PTransform):
         deadletter_queues = {
             # "pages": pages
             # | "WritePagesToBigQuery"
-            # >> WriteBigQuery(
+            # >> transformation.WriteBigQuery(
             #     table=lambda row: utils.format_table_name(
             #         row, self.summary_options.dataset_summary_pages
             #     ),
             #     schema=constants.BIGQUERY["schemas"]["summary_pages"],
             #     streaming=self.standard_options.streaming,
             #     method=self.summary_options.big_query_write_method,
+            #     triggering_frequency=self.triggering_frequency,
             # ),
             "home_pages": home_pages
             | "WriteHomePagesToBigQuery"
-            >> WriteBigQuery(
+            >> transformation.WriteBigQuery(
                 table=lambda row: utils.format_table_name(
                     row, self.summary_options.dataset_summary_pages_home_only
                 ),
                 schema=constants.BIGQUERY["schemas"]["summary_pages"],
                 streaming=self.standard_options.streaming,
                 method=self.summary_options.big_query_write_method,
+                triggering_frequency=self.triggering_frequency
             ),
         }
 
-        if self.standard_options.streaming:
+        if self.summary_options.big_query_write_method == bigquery.WriteToBigQuery.Method.STREAMING_INSERTS:
             add_deadletter_logging(deadletter_queues)
 
 
 class WriteSummaryRequestsToBigQuery(beam.PTransform):
-    def __init__(self, summary_options, standard_options, label=None):
+    def __init__(self, summary_options, standard_options, triggering_frequency=None, label=None, **kwargs):
         super().__init__(label)
         self.summary_options = summary_options
         self.standard_options = standard_options
+        self.triggering_frequency = triggering_frequency
 
     def expand(self, requests):
         requests = requests | "FlattenRequests" >> beam.FlatMap(
@@ -61,25 +63,27 @@ class WriteSummaryRequestsToBigQuery(beam.PTransform):
         deadletter_queues = {
             # "requests": requests
             # | "WriteRequestsToBigQuery"
-            # >> WriteBigQuery(
+            # >> transformation.WriteBigQuery(
             #     table=lambda row: utils.format_table_name(
             #         row, self.summary_options.dataset_summary_requests
             #     ),
             #     schema=constants.BIGQUERY["schemas"]["summary_requests"],
             #     streaming=self.standard_options.streaming,
             #     method=self.summary_options.big_query_write_method,
+            #     triggering_frequency = self.triggering_frequency,
             # ),
             "home_requests": home_requests
             | "WriteHomeRequestsToBigQuery"
-            >> WriteBigQuery(
+            >> transformation.WriteBigQuery(
                 table=lambda row: utils.format_table_name(
                     row, self.summary_options.dataset_summary_requests_home_only
                 ),
                 schema=constants.BIGQUERY["schemas"]["summary_requests"],
                 streaming=self.standard_options.streaming,
                 method=self.summary_options.big_query_write_method,
+                triggering_frequency=self.triggering_frequency,
             ),
         }
 
-        if self.standard_options.streaming:
+        if self.summary_options.big_query_write_method == bigquery.WriteToBigQuery.Method.STREAMING_INSERTS:
             add_deadletter_logging(deadletter_queues)

--- a/modules/summary_pipeline.py
+++ b/modules/summary_pipeline.py
@@ -17,16 +17,16 @@ class WriteSummaryPagesToBigQuery(beam.PTransform):
         home_pages = pages | "FilterHomePages" >> beam.Filter(utils.is_home_page)
 
         deadletter_queues = {
-            "pages": pages
-            | "WritePagesToBigQuery"
-            >> WriteBigQuery(
-                table=lambda row: utils.format_table_name(
-                    row, self.summary_options.dataset_summary_pages
-                ),
-                schema=constants.BIGQUERY["schemas"]["summary_pages"],
-                streaming=self.standard_options.streaming,
-                method=self.summary_options.big_query_write_method,
-            ),
+            # "pages": pages
+            # | "WritePagesToBigQuery"
+            # >> WriteBigQuery(
+            #     table=lambda row: utils.format_table_name(
+            #         row, self.summary_options.dataset_summary_pages
+            #     ),
+            #     schema=constants.BIGQUERY["schemas"]["summary_pages"],
+            #     streaming=self.standard_options.streaming,
+            #     method=self.summary_options.big_query_write_method,
+            # ),
             "home_pages": home_pages
             | "WriteHomePagesToBigQuery"
             >> WriteBigQuery(
@@ -59,16 +59,16 @@ class WriteSummaryRequestsToBigQuery(beam.PTransform):
         )
 
         deadletter_queues = {
-            "requests": requests
-            | "WriteRequestsToBigQuery"
-            >> WriteBigQuery(
-                table=lambda row: utils.format_table_name(
-                    row, self.summary_options.dataset_summary_requests
-                ),
-                schema=constants.BIGQUERY["schemas"]["summary_requests"],
-                streaming=self.standard_options.streaming,
-                method=self.summary_options.big_query_write_method,
-            ),
+            # "requests": requests
+            # | "WriteRequestsToBigQuery"
+            # >> WriteBigQuery(
+            #     table=lambda row: utils.format_table_name(
+            #         row, self.summary_options.dataset_summary_requests
+            #     ),
+            #     schema=constants.BIGQUERY["schemas"]["summary_requests"],
+            #     streaming=self.standard_options.streaming,
+            #     method=self.summary_options.big_query_write_method,
+            # ),
             "home_requests": home_requests
             | "WriteHomeRequestsToBigQuery"
             >> WriteBigQuery(

--- a/modules/summary_pipeline.py
+++ b/modules/summary_pipeline.py
@@ -16,17 +16,6 @@ class WriteSummaryPagesToBigQuery(beam.PTransform):
         home_pages = pages | "FilterHomePages" >> beam.Filter(utils.is_home_page)
 
         deadletter_queues = {
-            # "pages": pages
-            # | "WritePagesToBigQuery"
-            # >> transformation.WriteBigQuery(
-            #     table=lambda row: utils.format_table_name(
-            #         row, self.summary_options.dataset_summary_pages
-            #     ),
-            #     schema=constants.BIGQUERY["schemas"]["summary_pages"],
-            #     streaming=self.standard_options.streaming,
-            #     method=self.summary_options.big_query_write_method,
-            #     triggering_frequency=self.triggering_frequency,
-            # ),
             "home_pages": home_pages
             | "WriteHomePagesToBigQuery"
             >> transformation.WriteBigQuery(
@@ -61,17 +50,6 @@ class WriteSummaryRequestsToBigQuery(beam.PTransform):
         )
 
         deadletter_queues = {
-            # "requests": requests
-            # | "WriteRequestsToBigQuery"
-            # >> transformation.WriteBigQuery(
-            #     table=lambda row: utils.format_table_name(
-            #         row, self.summary_options.dataset_summary_requests
-            #     ),
-            #     schema=constants.BIGQUERY["schemas"]["summary_requests"],
-            #     streaming=self.standard_options.streaming,
-            #     method=self.summary_options.big_query_write_method,
-            #     triggering_frequency = self.triggering_frequency,
-            # ),
             "home_requests": home_requests
             | "WriteHomeRequestsToBigQuery"
             >> transformation.WriteBigQuery(

--- a/modules/transformation.py
+++ b/modules/transformation.py
@@ -93,7 +93,7 @@ class WriteBigQuery(beam.PTransform):
             return {
                 "method": WriteToBigQuery.Method.STREAMING_INSERTS,
                 "create_disposition": create_disposition,
-                "write_disposition": BigQueryDisposition.WRITE_APPEND,
+                "write_disposition": write_disposition,
                 "insert_retry_strategy": RetryStrategy.RETRY_ON_TRANSIENT_ERROR,
                 "with_auto_sharding": self.streaming,
                 "ignore_unknown_columns": True,

--- a/modules/transformation.py
+++ b/modules/transformation.py
@@ -83,7 +83,7 @@ class WriteBigQuery(beam.PTransform):
 
         # set a 15-minute default for triggering_frequency for streaming pipelines with BigQuery file loads
         if self.streaming and self.method == WriteToBigQuery.Method.FILE_LOADS and self.triggering_frequency is None:
-            self.triggering_frequency = 15
+            self.triggering_frequency = 15 * 60
 
     def resolve_params(self):
         # workaround/temporary - never create tables when streaming

--- a/modules/transformation.py
+++ b/modules/transformation.py
@@ -84,8 +84,10 @@ class WriteBigQuery(beam.PTransform):
     def resolve_params(self):
         if self.streaming:
             create_disposition = BigQueryDisposition.CREATE_NEVER
+            write_disposition = BigQueryDisposition.WRITE_APPEND
         else:
             create_disposition = BigQueryDisposition.CREATE_IF_NEEDED
+            write_disposition = BigQueryDisposition.WRITE_TRUNCATE
 
         if self.method == WriteToBigQuery.Method.STREAMING_INSERTS:
             return {
@@ -101,7 +103,7 @@ class WriteBigQuery(beam.PTransform):
             return {
                 "method": WriteToBigQuery.Method.FILE_LOADS,
                 "create_disposition": create_disposition,
-                "write_disposition": BigQueryDisposition.WRITE_TRUNCATE,
+                "write_disposition": write_disposition,
                 "additional_bq_parameters": {"ignoreUnknownValues": True},
                 "triggering_frequency": self.triggering_frequency
             }

--- a/modules/transformation.py
+++ b/modules/transformation.py
@@ -84,7 +84,7 @@ class WriteBigQuery(beam.PTransform):
         if self.method == WriteToBigQuery.Method.STREAMING_INSERTS:
             return {
                 "method": WriteToBigQuery.Method.STREAMING_INSERTS,
-                "create_disposition": BigQueryDisposition.CREATE_IF_NEEDED,
+                "create_disposition": BigQueryDisposition.CREATE_NEVER,
                 "write_disposition": BigQueryDisposition.WRITE_APPEND,
                 "insert_retry_strategy": RetryStrategy.RETRY_ON_TRANSIENT_ERROR,
                 "with_auto_sharding": self.streaming,

--- a/modules/transformation.py
+++ b/modules/transformation.py
@@ -81,6 +81,10 @@ class WriteBigQuery(beam.PTransform):
         self.method = method
         self.triggering_frequency = triggering_frequency
 
+        # set a 15-minute default for triggering_frequency for streaming pipelines with BigQuery file loads
+        if self.streaming and self.method == WriteToBigQuery.Method.FILE_LOADS and self.triggering_frequency is None:
+            self.triggering_frequency = 15
+
     def resolve_params(self):
         # workaround/temporary - never create tables when streaming
         # to avoid thundering herd issues where multiple workers attempt to create tables concurrently


### PR DESCRIPTION
Fixes #110, fixes #103

Changes

- Streaming BigQuery inserts should not create new tables - this is a temporary solution to avoid thundering herd issues. We saw many "get_or_create" errors when setting the BigQuery write disposition to `CREATE_IF_NEEDED`
- Forcing response bodies to use BigQuery file load jobs rather than streaming inserts in all cases to prevent quota errors
- Disable home+secondary writes - limit the number of BigQuery inserts (home+secondary tables will be generated later in a separate job)
- Add `triggering_frequency` parameter for the combined pipeline job to control how often to flush batches to BigQuery (works for both file load jobs and streaming inserts). Default is 15 minutes when using a streaming pipeline with File Loads

Validation job - streaming July 1, 2022
https://console.cloud.google.com/dataflow/jobs/us-west1/2022-07-03_11_36_53-14273886500850787916?project=httparchive