### PR TITLE
Fix `doctype` - stringify output

### DIFF
--- a/modules/transformation.py
+++ b/modules/transformation.py
@@ -438,6 +438,12 @@ class HarJsonToSummary:
             int(float(page.get("_avg_dom_depth"))) if page.get("_avg_dom_depth") else 0
         )
 
+        doc_type = (
+            json.dumps(page.get("_doctype"))
+            if page.get("_doctype")
+            else None
+        )
+
         return {
             "metadata": json.dumps(page.get("_metadata")),  # TODO TEST ME
             "client": status_info["client"],
@@ -468,7 +474,7 @@ class HarJsonToSummary:
             "_connections": page.get("_connections"),
             "_adult_site": page.get("_adult_site", False),
             "avg_dom_depth": avg_dom_depth,
-            "doctype": page.get("_doctype"),
+            "doctype": doc_type,
             "document_height": document_height,
             "document_width": document_width,
             "localstorage_size": localstorage_size,

--- a/modules/transformation.py
+++ b/modules/transformation.py
@@ -439,7 +439,7 @@ class HarJsonToSummary:
         )
 
         doc_type = (
-            json.dumps(page.get("_doctype"))
+            str(page.get("_doctype"))
             if page.get("_doctype")
             else None
         )


### PR DESCRIPTION
Fixes errors from the August 2022 combined pipeline jobs.

### Example failed BigQuery load job:
`gcloud alpha --project httparchive bq jobs describe
beam_bq_job_LOAD_crawlcombinedchromeaug_LOAD_STEP_715_c4171e83c7d902d748cff9204672095e_4c285624e8914028a6ba7cb65525dbe8`

```
[...]
- location: gs://httparchive-staging/experimental/temp/bq_load/9b7fdbc06b294deeb0bd258b7e7ae903/httparchive.summary_pages.2022_08_01_desktop/69a87b89-5cef-4630-8ee2-7a97b76c2b0c
    message: 'Error while reading data, error message: JSON parsing error in row starting
      at position 2742470: JSON object specified for non-record field: doctype File:
      gs://httparchive-staging/experimental/temp/bq_load/9b7fdbc06b294deeb0bd258b7e7ae903/httparchive.summary_pages.2022_08_01_desktop/69a87b89-5cef-4630-8ee2-7a97b76c2b0c'
    reason: invalid
```

### Failed dataflow jobs (before change):
- [crawl-combined-chrome-aug](https://console.cloud.google.com/dataflow/jobs/us-west1/2022-08-13_10_01_48-18069602258019047057?project=httparchive)
- [crawl-combined-android-aug](https://console.cloud.google.com/dataflow/jobs/us-west1/2022-08-12_10_37_01-15318025724030219405?project=httparchive)

### Successful dataflow jobs (after first commit):
Full jobs using `json.dumps()`
- [crawl-combined-chrome-aug](https://console.cloud.google.com/dataflow/jobs/us-west1/2022-08-14_18_10_52-13098664138147802974?project=httparchive)
- [crawl-combined-android-aug](https://console.cloud.google.com/dataflow/jobs/us-west1/2022-08-15_18_23_40-18224213604491603924?project=httparchive)

Partial dataflow job (after second commit):
- [giancarlo-pr126-combined-aug](https://console.cloud.google.com/dataflow/jobs/us-west1/2022-08-18_18_02_31-18063508245188630142?project=httparchive)