### PR TITLE
Bug/backfill fixes

### DIFF
--- a/modules/import_all.py
+++ b/modules/import_all.py
@@ -173,12 +173,13 @@ def get_features(page, wptid):
                     continue
 
                 feature_names.append({"feature": key, "type": feature_type, "id": ""})
-        except ValueError:
+        except (ValueError, AttributeError):
             logging.warning(
                 "Unable to get feature names for %s. Feature_type: %s, feature_map: %s",
                 wptid,
                 feature_type,
                 feature_map,
+                exc_info=True,
             )
 
         return feature_names

--- a/modules/import_all.py
+++ b/modules/import_all.py
@@ -91,7 +91,7 @@ def get_page(max_content_size, file_name, har):
         "lighthouse": lighthouse,
         "features": features,
         "technologies": technologies,
-        "metadata": to_json(metadata),
+        "metadata": to_json(metadata) if metadata else None,
     }
 
     if json_exceeds_max_content_size(ret, max_content_size, "pages", wptid):

--- a/modules/transformation.py
+++ b/modules/transformation.py
@@ -107,10 +107,7 @@ class HarJsonToSummary:
 
         date, client_name = utils.date_and_client_from_file_name(file_name)
 
-        metadata = page.get("_metadata", {})
-
-        # `_metadata.pageid` used on and prior to 2022-03-01, `_metadata.page_id` used going forward
-        pageid = metadata["page_id"] if "page_id" in metadata else metadata["pageid"]
+        metadata = page.get("_metadata")
 
         return {
             "archive": "All",  # only one value found when porting logic from PHP
@@ -119,10 +116,11 @@ class HarJsonToSummary:
             "wptid": page.get("testID", base_name.split(".")[0]),
             "medianRun": 1,  # only available in RAW json (median.firstview.run), not HAR json
             "page": metadata.get("tested_url", ""),
-            "pageid": utils.clamp_integer(pageid),
-            "rank": utils.clamp_integer(metadata["rank"])
-            if metadata.get("rank")
-            else None,
+            "pageid": utils.clamp_integer(
+                # `_metadata.pageid` used on and prior to 2022-03-01, `_metadata.page_id` used going forward
+                metadata["page_id"] if "page_id" in metadata else metadata["pageid"]
+            ),
+            "rank": utils.clamp_integer(metadata["rank"]) if metadata.get("rank") else None,
             "date": "{:%Y_%m_%d}".format(date),
             "client": metadata.get("layout", client_name).lower(),
         }

--- a/modules/transformation.py
+++ b/modules/transformation.py
@@ -109,6 +109,9 @@ class HarJsonToSummary:
 
         metadata = page.get("_metadata", {})
 
+        # `_metadata.pageid` used on and prior to 2022-03-01, `_metadata.page_id` used going forward
+        pageid = metadata["page_id"] if "page_id" in metadata else metadata["pageid"]
+
         return {
             "archive": "All",  # only one value found when porting logic from PHP
             "label": "{dt:%b} {dt.day} {dt.year}".format(dt=date),
@@ -116,9 +119,7 @@ class HarJsonToSummary:
             "wptid": page.get("testID", base_name.split(".")[0]),
             "medianRun": 1,  # only available in RAW json (median.firstview.run), not HAR json
             "page": metadata.get("tested_url", ""),
-            "pageid": utils.clamp_integer(metadata["page_id"])
-            if metadata.get("page_id")
-            else None,
+            "pageid": utils.clamp_integer(pageid),
             "rank": utils.clamp_integer(metadata["rank"])
             if metadata.get("rank")
             else None,


### PR DESCRIPTION
Progress on #15 - backfilling `all` tables.

### Changes
* [Avoid error when parsing empty metadata in import_all.get_page()](https://github.com/HTTPArchive/data-pipeline/commit/d9f01701d5168d5c3dfff42ae783517d19e9ebb8)
* [Extract pageid from older metadata format](https://github.com/HTTPArchive/data-pipeline/commit/5b6740d079f8d2259dbe13aa0b20482dfe42280a) (i.e. `pageid` rather than `page_id`)
* [Catch AttributeError when parsing features](https://github.com/HTTPArchive/data-pipeline/commit/0974aa5a00d1580ddbe96d3355b2fe7928500e1b)

### Previous failed backfill jobs
[March](https://console.cloud.google.com/dataflow/jobs/us-west1/2022-08-22_21_12_15-17816784191792003729?project=httparchive)
```
  File "/usr/local/lib/python3.8/site-packages/modules/import_all.py", line 62, in get_page
    features = get_features(page, wptid)
  File "/usr/local/lib/python3.8/site-packages/modules/import_all.py", line 191, in get_features
    + get_feature_names(blink_features.get("AnimatedCSSFeatures"), "animated-css")
  File "/usr/local/lib/python3.8/site-packages/modules/import_all.py", line 161, in get_feature_names
    for (key, value) in feature_map.items():
AttributeError: 'list' object has no attribute 'items'
```

```
[TypeError: unsupported operand type(s) for <<: 'NoneType' and 'int'](https://console.cloud.google.com/errors/CMj-xeyat-PO5QE?time=P1D&project=httparchive)
```

[April](https://console.cloud.google.com/dataflow/jobs/us-west1/2022-08-27_07_53_53-4289202942164317330?project=httparchive)
```
  File "/usr/local/lib/python3.8/site-packages/modules/import_all.py", line 62, in get_page
    features = get_features(page, wptid)
  File "/usr/local/lib/python3.8/site-packages/modules/import_all.py", line 191, in get_features
    + get_feature_names(blink_features.get("AnimatedCSSFeatures"), "animated-css")
  File "/usr/local/lib/python3.8/site-packages/modules/import_all.py", line 161, in get_feature_names
    for (key, value) in feature_map.items():
AttributeError: 'list' object has no attribute 'items'
```

```
TypeError: 'NoneType' object is not subscriptable

at .aggregate_stats ( [/usr/local/lib/python3.8/site-packages/modules/transformation.py:541](https://console.cloud.google.com/debug?referrer=fromlog&file=%2Fusr%2Flocal%2Flib%2Fpython3.8%2Fsite-packages%2Fmodules%2Ftransformation.py&line=541&project=httparchive) )
at .generate_pages ( [/usr/local/lib/python3.8/site-packages/modules/transformation.py:172](https://console.cloud.google.com/debug?referrer=fromlog&file=%2Fusr%2Flocal%2Flib%2Fpython3.8%2Fsite-packages%2Fmodules%2Ftransformation.py&line=172&project=httparchive) )
at .get_page ( [/usr/local/lib/python3.8/site-packages/modules/import_all.py:67](https://console.cloud.google.com/debug?referrer=fromlog&file=%2Fusr%2Flocal%2Flib%2Fpython3.8%2Fsite-packages%2Fmodules%2Fimport_all.py&line=67&project=httparchive) )
```

### Successful backfill jobs, post-update
[March](https://console.cloud.google.com/dataflow/jobs/us-west1/2022-08-26_21_33_49-6380032595741838847?project=httparchive)
[April](https://console.cloud.google.com/dataflow/jobs/us-west1/2022-08-28_14_16_17-15058342196587108761?project=httparchive)