### PR TITLE
Fix dataflow flex template version bumping github action

### DIFF
--- a/.github/workflows/deploy-cloud-workflow.yml
+++ b/.github/workflows/deploy-cloud-workflow.yml
@@ -7,14 +7,11 @@ on:
       - main
     paths:
       - "data-pipeline.workflows.yaml"
-  workflow_run:
-    workflows: ["Deploy Dataflow Flex Template"]
-    types: ["completed"]
 
 jobs:
   deploy:
     name: Deploy Cloud Workflow
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - id: 'auth'

--- a/.github/workflows/deploy-dataflow-flex-template.yml
+++ b/.github/workflows/deploy-dataflow-flex-template.yml
@@ -29,7 +29,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v1
       - name: Run build script
         id: build_flex_template
-        run: echo "BUILD_TAG=$(build_flex_template.sh)" >> $GITHUB_OUTPUT
+        run: echo "BUILD_TAG=$(./build_flex_template.sh)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Update Cloud Workflow build tag
         # yamllint disable rule:line-length

--- a/.github/workflows/deploy-dataflow-flex-template.yml
+++ b/.github/workflows/deploy-dataflow-flex-template.yml
@@ -11,8 +11,6 @@ on:
       - "Dockerfile"
       - "flex_template_metadata_*.json"
       - "requirements.txt"
-  # TODO: remove before merging to main
-  pull_request:
 
 jobs:
   deploy:
@@ -27,7 +25,7 @@ jobs:
           credentials_json: '${{ secrets.GCP_SA_KEY }}'
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1
-      - name: Run build script
+      - name: Build flex templates
         id: build_flex_template
         run: echo "BUILD_TAG=$(./build_flex_template.sh | tail -1)" >> $GITHUB_OUTPUT
         shell: bash

--- a/.github/workflows/deploy-dataflow-flex-template.yml
+++ b/.github/workflows/deploy-dataflow-flex-template.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Run build script
         id: build_flex_template
         run: echo "BUILD_TAG=$(./build_flex_template.sh)" >> $GITHUB_OUTPUT
-        shell: bash
+        shell: bash {0}
       - name: Update Cloud Workflow build tag
         # yamllint disable rule:line-length
         run: sed -ri 's/^(\s*-\sflexTemplateBuildTag:)(\s".+"$)/\1 "${{ steps.build_flex_template.outputs.BUILD_TAG }}"/' data-pipeline.workflows.yaml

--- a/.github/workflows/deploy-dataflow-flex-template.yml
+++ b/.github/workflows/deploy-dataflow-flex-template.yml
@@ -33,22 +33,22 @@ jobs:
         shell: bash
       - name: Update Cloud Workflow build tag
         # yamllint disable rule:line-length
-        run: |
-          sed -ri 's/^(\s*-\sflexTemplateBuildTag:)(\s".+"$)/\1 "${{ steps.build_flex_template.outputs.BUILD_TAG }}"/' data-pipeline.workflows.yaml
-          grep flexTemplateBuildTag: data-pipeline.workflows.yaml
-      # - name: Create Pull Request
-      #   id: cpr
-      #   uses: peter-evans/create-pull-request@v4
-      #   with:
-      #     add-paths: |
-      #       data-pipeline.workflows.yaml
-      #     branch-suffix: timestamp
-      #     commit-message: Bump dataflow flex template build tag
-      #     title: Bump dataflow flex template build tag
-      #     body: |
-      #       Bump dataflow flex template build tag to: ${{ steps.build_flex_template.outputs.BUILD_TAG }}
+        run: sed -ri 's/^(\s*-\sflexTemplateBuildTag:)(\s".+"$)/\1 "${{ steps.build_flex_template.outputs.BUILD_TAG }}"/' data-pipeline.workflows.yaml
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v4
+        with:
+          add-paths: |
+            data-pipeline.workflows.yaml
+          branch-suffix: timestamp
+          commit-message: Bump dataflow flex template build tag
+          title: Bump dataflow flex template build tag
+          body: |
+            Bump dataflow flex template build tag to: ${{ steps.build_flex_template.outputs.BUILD_TAG }}
 
-      #       Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action
-      # - name: Check outputs
-      #   run: echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+            Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action
+      - name: Check outputs
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
 

--- a/.github/workflows/deploy-dataflow-flex-template.yml
+++ b/.github/workflows/deploy-dataflow-flex-template.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Run build script
         id: build_flex_template
         run: echo "BUILD_TAG=$(build_flex_template.sh)" >> $GITHUB_OUTPUT
+        shell: bash
       - name: Update Cloud Workflow build tag
         # yamllint disable rule:line-length
         run: sed -ri 's/^(\s*-\sflexTemplateBuildTag:)(\s".+"$)/\1 "${{ steps.build_flex_template.outputs.BUILD_TAG }}"/' data-pipeline.workflows.yaml

--- a/.github/workflows/deploy-dataflow-flex-template.yml
+++ b/.github/workflows/deploy-dataflow-flex-template.yml
@@ -11,11 +11,13 @@ on:
       - "Dockerfile"
       - "flex_template_metadata_*.json"
       - "requirements.txt"
+  # TODO: remove before merging to main
+  pull_request:
 
 jobs:
   deploy:
     name: Deploy Dataflow Flex Template
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - id: 'auth'
@@ -31,9 +33,19 @@ jobs:
       - name: Update Cloud Workflow build tag
         # yamllint disable rule:line-length
         run: sed -ri 's/^(\s*-\sflexTemplateBuildTag:)(\s".+"$)/\1 "${{ steps.build_flex_template.outputs.BUILD_TAG }}"/' data-pipeline.workflows.yaml
-      - name: Auto Commit Cloud Workflow Update
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: Bump data-pipeline.workflows.yaml to ${{ steps.build_flex_template.outputs.BUILD_TAG }}
-          file_pattern: data-pipeline.workflows.yaml
+      # - name: Create Pull Request
+      #   id: cpr
+      #   uses: peter-evans/create-pull-request@v4
+      #   with:
+      #     add-paths: |
+      #       data-pipeline.workflows.yaml
+      #     branch-suffix: timestamp
+      #     commit-message: Bump dataflow flex template build tag
+      #     title: Bump dataflow flex template build tag
+      #     body: |
+      #       Bump dataflow flex template build tag to: ${{ steps.build_flex_template.outputs.BUILD_TAG }}
+
+      #       Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action
+      # - name: Check outputs
+      #   run: echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
 

--- a/.github/workflows/deploy-dataflow-flex-template.yml
+++ b/.github/workflows/deploy-dataflow-flex-template.yml
@@ -29,7 +29,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v1
       - name: Run build script
         id: build_flex_template
-        run: echo "BUILD_TAG=$(./build_flex_template.sh)" >> $GITHUB_OUTPUT
+        run: echo "BUILD_TAG=$(./build_flex_template.sh | tail -1)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Update Cloud Workflow build tag
         # yamllint disable rule:line-length

--- a/.github/workflows/deploy-dataflow-flex-template.yml
+++ b/.github/workflows/deploy-dataflow-flex-template.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Run build script
         id: build_flex_template
         run: echo "BUILD_TAG=$(./build_flex_template.sh)" >> $GITHUB_OUTPUT
-        shell: bash {0}
+        shell: bash
       - name: Update Cloud Workflow build tag
         # yamllint disable rule:line-length
         run: sed -ri 's/^(\s*-\sflexTemplateBuildTag:)(\s".+"$)/\1 "${{ steps.build_flex_template.outputs.BUILD_TAG }}"/' data-pipeline.workflows.yaml

--- a/.github/workflows/deploy-dataflow-flex-template.yml
+++ b/.github/workflows/deploy-dataflow-flex-template.yml
@@ -33,7 +33,9 @@ jobs:
         shell: bash
       - name: Update Cloud Workflow build tag
         # yamllint disable rule:line-length
-        run: sed -ri 's/^(\s*-\sflexTemplateBuildTag:)(\s".+"$)/\1 "${{ steps.build_flex_template.outputs.BUILD_TAG }}"/' data-pipeline.workflows.yaml
+        run: |
+          sed -ri 's/^(\s*-\sflexTemplateBuildTag:)(\s".+"$)/\1 "${{ steps.build_flex_template.outputs.BUILD_TAG }}"/' data-pipeline.workflows.yaml
+          grep flexTemplateBuildTag: data-pipeline.workflows.yaml
       # - name: Create Pull Request
       #   id: cpr
       #   uses: peter-evans/create-pull-request@v4

--- a/build_flex_template.sh
+++ b/build_flex_template.sh
@@ -3,7 +3,7 @@
 set -e
 set -u
 
-BUILD_TAG=$(date +"%Y-%m-%d_%H-%M-%S")
+BUILD_TAG=$(date -u +"%Y-%m-%d_%H-%M-%S")
 
 # for type in all combined
 # do

--- a/build_flex_template.sh
+++ b/build_flex_template.sh
@@ -5,9 +5,18 @@ set -u
 
 BUILD_TAG=$(date +"%Y-%m-%d_%H-%M-%S")
 
-for type in all combined
-do
-    gcloud builds submit --substitutions=_TYPE="${type}",_BUILD_TAG="${BUILD_TAG}" .
-done
+# for type in all combined
+# do
+#     gcloud builds submit --substitutions=_TYPE="${type}",_BUILD_TAG="${BUILD_TAG}" .
+# done
+
+>&2 echo log error spew1
+echo log spew
+echo log spew
+echo log spew
+>&2 echo log error spew2
+echo log spew
+echo log spew
+echo log spew
 
 echo "${BUILD_TAG}"

--- a/build_flex_template.sh
+++ b/build_flex_template.sh
@@ -5,18 +5,9 @@ set -u
 
 BUILD_TAG=$(date -u +"%Y-%m-%d_%H-%M-%S")
 
-# for type in all combined
-# do
-#     gcloud builds submit --substitutions=_TYPE="${type}",_BUILD_TAG="${BUILD_TAG}" .
-# done
-
->&2 echo log error spew1
-echo log spew
-echo log spew
-echo log spew
->&2 echo log error spew2
-echo log spew
-echo log spew
-echo log spew
+for type in all combined
+do
+    gcloud builds submit --substitutions=_TYPE="${type}",_BUILD_TAG="${BUILD_TAG}" .
+done
 
 echo "${BUILD_TAG}"

--- a/run_flex_template.sh
+++ b/run_flex_template.sh
@@ -8,7 +8,7 @@ REGION="us-west1"
 
 # type is the first script argument
 TYPE="${1}"
-DF_JOB_ID="${REPO}-${TYPE}-$(date +%Y%m%d-%H%M%S)"
+DF_JOB_ID="${REPO}-${TYPE}-$(date -u +%Y%m%d-%H%M%S)"
 DF_TEMP_BUCKET="gs://${PROJECT}-staging/dataflow"
 TEMPLATE_BASE_PATH="gs://${PROJECT}/dataflow/templates"
 


### PR DESCRIPTION
Follow up to #162 

# Changes

- Switched to creating a new GitHub Pull Request to bump the flex template tag on the `main` branch rather than auto-committing to the feature branch (not permitted without creating a new Personal Access Token)
- Removed workflow deployment for every flex template action run (should only run from the main branch instead)
- Updated flex template build tag and job id to use UTC time instead of local time
- Update from `ubuntu-18.04` to `ubuntu-latest` GitHub Actions runners
