### PR TITLE
Specify workflows service account in deploy GHA

### DIFF
--- a/.github/workflows/deploy-cloud-workflow.yml
+++ b/.github/workflows/deploy-cloud-workflow.yml
@@ -29,4 +29,4 @@ jobs:
           --project ${{ secrets.GCP_PROJECT_ID }} \
           --description "Runs the HTTPArchive data pipeline" \
           --labels "commit-sha=${{ github.sha }}" \
-          --service-account github-actions@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+          --service-account workflows@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com


### PR DESCRIPTION
Previous workflow execution failed due to permission error: `Permission 'logging.logEntries.create' denied on resource (or it may not exist)`

The `workflows` service account should be used for execution instead of `github-actions` one.