### PR TITLE
Add check for valid GZIPs

### DIFF
--- a/modules/transformation.py
+++ b/modules/transformation.py
@@ -29,7 +29,7 @@ class ReadHarFiles(beam.PTransform):
     def is_valid_gzip(path):
         try:
             with FileSystems.open(path, compression_type=CompressionTypes.GZIP) as handle:
-                handle.peek()
+                handle.readline()
                 return True
         except Exception:
             logging.exception(f"Unable to read file: {path=}")


### PR DESCRIPTION
# Changes
Add filter to check GZIP format before fully reading. 

Error encountered during Dataflow job execution of the 2023 February crawl: `zlib.error: Error -3 while decompressing data: incorrect header check [while running 'ReadHarFiles/ReadAllFromText/ReadAllFiles/ReadRange']`

Previously failed job: https://console.cloud.google.com/dataflow/jobs/us-west1/2023-02-07_19_08_40-6615087461148694290?project=httparchive

# Validation

Re-run previously failed job for `all`, `desktop`: https://console.cloud.google.com/dataflow/jobs/us-west1/2023-02-07_23_58_30-18316823327085365589?project=httparchive

Error is handled more permissively now with logging instead of failure.

Example [pinned log](https://console.cloud.google.com/logs/query;cursorTimestamp=2023-02-08T08:13:18.660160541Z;pinnedLogId=2023-02-08T08:13:18.660160541Z%2F7240805713038992980:141716:0:20458;query=resource.type%3D%22dataflow_step%22%0Aresource.labels.job_id%3D%222023-02-07_23_58_30-18316823327085365589%22%0AlogName%3D%2528%22projects%2Fhttparchive%2Flogs%2Fdataflow.googleapis.com%252Fworker%22%20OR%20%22projects%2Fhttparchive%2Flogs%2Fdataflow.googleapis.com%252Fworker-startup%22%2529%0Atimestamp%3D%222023-02-08T08:13:18.660160541Z%22%0AinsertId%3D%227240805713038992980:141716:0:20458%22;timeRange=PT10M?project=httparchive)

```
{
[...]
  "jsonPayload": {
    [...]
    "step": "ReadHarFiles/Filter(is_valid_gzip)",
    "message": "Unable to read file: path='gs://httparchive/crawls/chrome-Feb_1_2023/230201_Dx95_1YL0Xl0.har.gz'",
    "job": "2023-02-07_23_58_30-18316823327085365589",
    "logger": "root:transformation.py:is_valid_gzip",
    "exception": "Traceback (most recent call last):\n  File \"/dataflow/template/modules/transformation.py\", line 32, in is_valid_gzip\n    handle.readline()\n  File \"/usr/local/lib/python3.8/site-packages/apache_beam/io/filesystem.py\", line 302, in readline\n    self._fetch_to_internal_buffer(self._read_size // 2)\n  File \"/usr/local/lib/python3.8/site-packages/apache_beam/io/filesystem.py\", line 252, in _fetch_to_internal_buffer\n    decompressed = self._decompressor.decompress(buf)\nzlib.error: Error -3 while decompressing data: incorrect header check\n"
  },
  "resource": {
    "type": "dataflow_step",
    "labels": {
      "region": "us-west1",
      "step_id": "ReadHarFiles/Filter(is_valid_gzip)",
      "job_id": "2023-02-07_23_58_30-18316823327085365589",
      "project_id": "httparchive",
      "job_name": "data-pipeline-all-20230208-075827"
    }
  },
  [...]
  "logName": "projects/httparchive/logs/dataflow.googleapis.com%2Fworker",
  "receiveTimestamp": "2023-02-08T08:13:37.729203453Z"
}
```
