### PR TITLE
More fixes to handle bad JSONs

### DIFF
--- a/modules/combined_pipeline.py
+++ b/modules/combined_pipeline.py
@@ -151,7 +151,7 @@ def create_pipeline(argv=None):
     if combined_options.pipeline_type in ["combined", "non-summary"]:
         (
             files
-            | "MapJSON" >> beam.FlatMapTuple(non_summary_pipeline.from_json)
+            | "MapJSON" >> beam.MapTuple(non_summary_pipeline.from_json)
             | "AddDateAndClient" >> beam.Map(non_summary_pipeline.add_date_and_client)
             | "WriteNonSummaryTables"
             >> non_summary_pipeline.WriteNonSummaryToBigQuery(

--- a/modules/import_all.py
+++ b/modules/import_all.py
@@ -511,7 +511,7 @@ def create_pipeline(argv=None):
     hars = (
         pipeline
         | ReadHarFiles(**vars(known_args))
-        | "MapJSON" >> beam.FlatMapTuple(from_json)
+        | "MapJSON" >> beam.MapTuple(from_json)
     )
 
     _ = (

--- a/modules/non_summary_pipeline.py
+++ b/modules/non_summary_pipeline.py
@@ -435,14 +435,18 @@ def from_json(file_name, element):
     """Returns an object from the JSON representation."""
 
     try:
-        return [(file_name, json.loads(element))]
+        return file_name, json.loads(element)
     except Exception as e:
         logging.error('Unable to parse file %s into JSON object "%s...": %s' % (file_name, element[:50], e))
-        return [(None)]
+        return None
 
 
 def add_date_and_client(element):
     """Adds `date` and `client` attributes to facilitate BigQuery table routing"""
+
+    if element is None:
+        logging.error('Element is emoty, skipping adding date and time')
+        return None
 
     try:
         file_name, har = element


### PR DESCRIPTION
Reverses some of the changes from #190 as they didn't work.

Adds an exlicit check for `None` before trying to add date and time.