### PR TITLE
Correct template build script

### DIFF
--- a/build_flex_template.sh
+++ b/build_flex_template.sh
@@ -5,6 +5,9 @@ set -u
 
 BUILD_TAG=$(date -u +"%Y-%m-%d_%H-%M-%S")
 
-gcloud builds submit --substitutions=_TYPE="combined",_BUILD_TAG="${BUILD_TAG}" .
+for type in all combined
+do
+    gcloud builds submit --substitutions=_TYPE="${type}",_BUILD_TAG="${BUILD_TAG}" .
+done
 
 echo "${BUILD_TAG}"

--- a/build_flex_template.sh
+++ b/build_flex_template.sh
@@ -5,12 +5,6 @@ set -u
 
 BUILD_TAG=$(date -u +"%Y-%m-%d_%H-%M-%S")
 
-gcloud builds submit --substitutions=_TYPE="all",_BUILD_TAG="${BUILD_TAG}" .
-
-# Sleep to ensure the previous command completes as in GitHub actions it
-# tries to run the builds in parallel which fails.
-sleep 600
-
 gcloud builds submit --substitutions=_TYPE="combined",_BUILD_TAG="${BUILD_TAG}" .
 
 echo "${BUILD_TAG}"

--- a/build_flex_template.sh
+++ b/build_flex_template.sh
@@ -7,6 +7,10 @@ BUILD_TAG=$(date -u +"%Y-%m-%d_%H-%M-%S")
 
 gcloud builds submit --substitutions=_TYPE="all",_BUILD_TAG="${BUILD_TAG}" .
 
+# Sleep to ensure the previous command completes as in GitHub actions it
+# tries to run the builds in parallel which fails.
+sleep 600
+
 gcloud builds submit --substitutions=_TYPE="combined",_BUILD_TAG="${BUILD_TAG}" .
 
 echo "${BUILD_TAG}"

--- a/build_flex_template.sh
+++ b/build_flex_template.sh
@@ -5,9 +5,8 @@ set -u
 
 BUILD_TAG=$(date -u +"%Y-%m-%d_%H-%M-%S")
 
-for type in all combined
-do
-    gcloud builds submit --substitutions=_TYPE="${type}",_BUILD_TAG="${BUILD_TAG}" .
-done
+gcloud builds submit --substitutions=_TYPE="all",_BUILD_TAG="${BUILD_TAG}" .
+
+gcloud builds submit --substitutions=_TYPE="combined",_BUILD_TAG="${BUILD_TAG}" .
 
 echo "${BUILD_TAG}"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,6 +2,9 @@ steps:
 - id: 'build_image'
   name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', '${_TEMPLATE_IMAGE}', '--build-arg=TYPE=${_TYPE}', '.']
+  logsBucket: 'gs://httparchive/dataflow/buildlogs'
+  options:
+    logging: GCS_ONLY
 - id: 'build_template'
   name: 'gcr.io/cloud-builders/gcloud'
   args:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,9 +2,6 @@ steps:
 - id: 'build_image'
   name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', '${_TEMPLATE_IMAGE}', '--build-arg=TYPE=${_TYPE}', '.']
-  logsBucket: 'gs://httparchive/dataflow/buildlogs'
-  options:
-    logging: GCS_ONLY
 - id: 'build_template'
   name: 'gcr.io/cloud-builders/gcloud'
   args:
@@ -32,3 +29,6 @@ substitutions:
 
 options:
   dynamic_substitutions: true
+  logging: GCS_ONLY
+
+logsBucket: 'gs://httparchive/dataflow/buildlogs'


### PR DESCRIPTION
The template build script was throwing an error when saving the log, meaning only the first `all` pipeline was updated, but then the `combined` one wasn't. This fixes that.