### PR TITLE
Fix cloud workflow build

### DIFF
--- a/.github/workflows/deploy-cloud-workflow.yml
+++ b/.github/workflows/deploy-cloud-workflow.yml
@@ -30,3 +30,6 @@ jobs:
           --description "Runs the HTTPArchive data pipeline" \
           --labels "commit-sha=${{ github.sha }}" \
           --service-account workflows@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+
+
+

--- a/.github/workflows/deploy-dataflow-flex-template.yml
+++ b/.github/workflows/deploy-dataflow-flex-template.yml
@@ -31,7 +31,7 @@ jobs:
         shell: bash
       - name: Update Cloud Workflow build tag
         # yamllint disable rule:line-length
-        run: sed -ri 's/^(\s*-\sflexTemplateBuildTag:)(\s".+"$)/\1 "${{ steps.build_flex_template.outputs.BUILD_TAG }}"/' data-pipeline.workflows.yaml
+        run: sed -ri 's/^(\s*-\sflexTemplateBuildTag:)(\s".*"$)/\1 "${{ steps.build_flex_template.outputs.BUILD_TAG }}"/' data-pipeline.workflows.yaml
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@v5

--- a/data-pipeline.workflows.yaml
+++ b/data-pipeline.workflows.yaml
@@ -22,7 +22,7 @@ main:
                   - project: ${sys.get_env("GOOGLE_CLOUD_PROJECT_ID")}
                   - region: "us-west1"
                   - flexTemplateRepo: "data-pipeline"
-                  - flexTemplateBuildTag: ""
+                  - flexTemplateBuildTag: "2023-07-21_13-17-25"
                   - flexTemplateBasePath: ${"gs://" + project + "/dataflow/templates/" + flexTemplateRepo}
                   - flexTemplateTemp: ${"gs://" + project + "-staging/dataflow"}
 


### PR DESCRIPTION
The `flexTemplateBuildTag` got broken in #191 as the previous build failed (as noted in #200) and so never gave the build tag so it was incorrectly updated to empty string.

Even after that was fixed it wasn't corrected as currently look for `".+"` (i.e. one or more chars) when it was now `""`. So changing that `+` to a `*` in case this happens again.