### PR TITLE
Fail build if tag is not set

### DIFF
--- a/.github/workflows/deploy-dataflow-flex-template.yml
+++ b/.github/workflows/deploy-dataflow-flex-template.yml
@@ -29,6 +29,10 @@ jobs:
         id: build_flex_template
         run: echo "BUILD_TAG=$(./build_flex_template.sh | tail -1)" >> $GITHUB_OUTPUT
         shell: bash
+      - name: Check BUILD_TAG
+        # Fail the run if the BUILD_TAG is empty
+        if: ${{ steps.build_flex_template.outputs.BUILD_TAG == '' }}
+        run: exit 1
       - name: Update Cloud Workflow build tag
         # yamllint disable rule:line-length
         run: sed -ri 's/^(\s*-\sflexTemplateBuildTag:)(\s".*"$)/\1 "${{ steps.build_flex_template.outputs.BUILD_TAG }}"/' data-pipeline.workflows.yaml


### PR DESCRIPTION
When our key expires the build fails silently and we get PRs like #218 which incorrectly blank out the template tag. Let's kill the run instead. 