### PR TITLE
1-based index in all.requests

### DIFF
--- a/schema/all_requests.json
+++ b/schema/all_requests.json
@@ -51,7 +51,7 @@
         "name": "index",
         "type": "INTEGER",
         "mode": "NULLABLE",
-        "description": "The sequential 0-based index of the request"
+        "description": "The sequential 1-based index of the request"
     },
     {
         "name": "payload",


### PR DESCRIPTION
From the first glance it seems to me as a simple error in column description.

1. [see line here](https://github.com/HTTPArchive/data-pipeline/blob/d0479063a3d7cc59723f4c71947c041276262852/modules/import_all.py#L308)

2. Query returns no results:
```sql
SELECT
  url,
  index,
  type,
  is_main_document,
  page
FROM `httparchive.all.requests`
WHERE
  date = '2024-06-01'
  AND client = 'mobile'
  AND is_root_page = TRUE
  AND index = 1
```

Please let me know if we actually expect a 0-based index.

Need to fix here too: https://har.fyi/reference/tables/requests/#index